### PR TITLE
Use undefined for default input value

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ class Calendar extends React.Component {
       maxDate,
       format,
       computableFormat,
-      inputValue: date ? date.format(format) : null,
+      inputValue: date ? date.format(format) : undefined,
       views: ['days', 'months', 'years'],
       minView,
       currentView: minView || 0,


### PR DESCRIPTION
As of React v15.0 input values must be strings or undefined. Cannot use null anymore as we get a warning.

Warning: `value` prop on `input` should not be null. Consider using the empty string to clear the component or `undefined` for uncontrolled components.